### PR TITLE
fix: Remove typo in key for calendar name.

### DIFF
--- a/lib/jmap/data_access/NextcloudCalendarDataAccess.php
+++ b/lib/jmap/data_access/NextcloudCalendarDataAccess.php
@@ -78,7 +78,7 @@ class NextcloudCalendarDataAccess extends AbstractDataAccess
             $name = $calendarToCreate['uri'];
             unset($calendarToCreate['uri']);
 
-            if (!isset($calendarToCreate["{DAV:}dsiplayname"])) {
+            if (!isset($calendarToCreate["{DAV:}displayname"])) {
                 $calendarToCreate["{DAV:}displayname"] = $name;
             }
 


### PR DESCRIPTION
Closes #4